### PR TITLE
Add tests and tweak `None` filter interest level

### DIFF
--- a/tracing-subscriber/src/filter/subscriber_filters/mod.rs
+++ b/tracing-subscriber/src/filter/subscriber_filters/mod.rs
@@ -541,7 +541,7 @@ where
     fn callsite_enabled(&self, meta: &'static Metadata<'static>) -> Interest {
         self.as_ref()
             .map(|inner| inner.callsite_enabled(meta))
-            .unwrap_or_else(Interest::sometimes)
+            .unwrap_or_else(Interest::always)
     }
 
     #[inline]

--- a/tracing-subscriber/tests/option_filter_interest_caching.rs
+++ b/tracing-subscriber/tests/option_filter_interest_caching.rs
@@ -1,0 +1,52 @@
+// A separate test crate for `Option<Filter>` for isolation from other tests
+// that may influence the interest cache.
+
+use std::sync::{Arc, atomic::{AtomicUsize, Ordering}};
+use tracing_mock::{subscriber, expect};
+use tracing_subscriber::{filter, prelude::*, Subscribe};
+
+/// A `None` filter should always be interested in events, and it should not
+/// needlessly degrade the caching of other filters.
+#[test]
+fn none_interest_cache() {
+    let (subscribe_none, handle_none) = subscriber::mock()
+        .event(expect::event())
+        .event(expect::event())
+        .only()
+        .run_with_handle();
+    let subscribe_none = subscribe_none
+        .with_filter(None::<filter::DynFilterFn<_>>);
+
+    let times_filtered = Arc::new(AtomicUsize::new(0));
+    let (subscribe_filter_fn, handle_filter_fn) = subscriber::mock()
+        .event(expect::event())
+        .event(expect::event())
+        .only()
+        .run_with_handle();
+    let subscribe_filter_fn = subscribe_filter_fn
+        .with_filter(filter::filter_fn({
+            let times_filtered = Arc::clone(&times_filtered);
+            move |_| {
+                times_filtered.fetch_add(1, Ordering::Relaxed);
+                true
+            }
+        }));
+
+    let subscriber = tracing_subscriber::registry()
+        .with(subscribe_none)
+        .with(subscribe_filter_fn);
+
+    let _guard = subscriber.set_default();
+    for _ in 0..2 {
+        tracing::debug!(target: "always_interesting", x="bar");
+    }
+
+    // The `None` filter is unchanging and performs no filtering, so it should
+    // be cacheable and always be interested in events. The filter fn is a
+    // non-dynamic filter fn, which means the result can be cached per callsite.
+    // The filter fn should only need to be called once, and the `Option` filter
+    // should not interfere in the caching of that result.
+    assert_eq!(times_filtered.load(Ordering::Relaxed), 1);
+    handle_none.assert_finished();
+    handle_filter_fn.assert_finished();
+}

--- a/tracing-subscriber/tests/subscriber_filters/option.rs
+++ b/tracing-subscriber/tests/subscriber_filters/option.rs
@@ -1,5 +1,6 @@
 use super::*;
-use tracing_subscriber::{filter, prelude::*, Subscribe};
+use tracing::Collect;
+use tracing_subscriber::{filter::{self, LevelFilter}, prelude::*, Subscribe};
 
 fn filter_out_everything<S>() -> filter::DynFilterFn<S> {
     // Use dynamic filter fn to disable interest caching and max-level hints,
@@ -57,4 +58,87 @@ fn option_mixed() {
     tracing::info!(target: "boring", x="bar");
 
     handle.assert_finished();
+}
+
+/// The lack of a max level hint from a `None` filter should result in no max
+/// level hint when combined with other filters/subscribers.
+#[test]
+fn none_max_level_hint() {
+    let (subscribe_none, handle_none) = subscriber::mock()
+        .event(expect::event())
+        .event(expect::event())
+        .only()
+        .run_with_handle();
+    let subscribe_none = subscribe_none
+        .with_filter(None::<filter::DynFilterFn<_>>);
+    assert!(subscribe_none.max_level_hint().is_none());
+
+    let (subscribe_filter_fn, handle_filter_fn) = subscriber::mock()
+        .event(expect::event())
+        .only()
+        .run_with_handle();
+    let max_level = Level::INFO;
+    let subscribe_filter_fn = subscribe_filter_fn
+        .with_filter(filter::dynamic_filter_fn(move |meta, _| {
+            return meta.level() <= &max_level
+        })
+        .with_max_level_hint(max_level));
+    assert_eq!(subscribe_filter_fn.max_level_hint(), Some(LevelFilter::INFO));
+
+    let subscriber = tracing_subscriber::registry()
+        .with(subscribe_none)
+        .with(subscribe_filter_fn);
+    // The absence of a hint from the `None` filter upgrades the `INFO` hint
+    // from the filter fn subscriber.
+    assert!(subscriber.max_level_hint().is_none());
+
+    let _guard = subscriber.set_default();
+    tracing::info!(target: "interesting", x="foo");
+    tracing::debug!(target: "sometimes_interesting", x="bar");
+
+    handle_none.assert_finished();
+    handle_filter_fn.assert_finished();
+}
+
+/// The max level hint from inside a `Some(filter)` filter should be propagated
+/// and combined with other filters/subscribers.
+#[test]
+fn some_max_level_hint() {
+    let (subscribe_some, handle_some) = subscriber::mock()
+        .event(expect::event())
+        .event(expect::event())
+        .only()
+        .run_with_handle();
+    let subscribe_some = subscribe_some
+        .with_filter(Some(
+            filter::dynamic_filter_fn(move |meta, _| {
+                return meta.level() <= &Level::DEBUG
+            }).with_max_level_hint(Level::DEBUG)
+        ));
+    assert_eq!(subscribe_some.max_level_hint(), Some(LevelFilter::DEBUG));
+
+    let (subscribe_filter_fn, handle_filter_fn) = subscriber::mock()
+        .event(expect::event())
+        .only()
+        .run_with_handle();
+    let subscribe_filter_fn = subscribe_filter_fn
+        .with_filter(filter::dynamic_filter_fn(move |meta, _| {
+            return meta.level() <= &Level::INFO
+        })
+        .with_max_level_hint(Level::INFO));
+    assert_eq!(subscribe_filter_fn.max_level_hint(), Some(LevelFilter::INFO));
+
+    let subscriber = tracing_subscriber::registry()
+        .with(subscribe_some)
+        .with(subscribe_filter_fn);
+    // The `DEBUG` hint from the `Some` filter upgrades the `INFO` hint from the
+    // filter fn subscriber.
+    assert_eq!(subscriber.max_level_hint(), Some(LevelFilter::DEBUG));
+
+    let _guard = subscriber.set_default();
+    tracing::info!(target: "interesting", x="foo");
+    tracing::debug!(target: "sometimes_interesting", x="bar");
+
+    handle_some.assert_finished();
+    handle_filter_fn.assert_finished();
 }


### PR DESCRIPTION
* Added tests for max level filtering and interest caching with multiple subscribers.
* Changed the interest level for a `None` filter from `sometimes` to `always` so other filters can be cached more effectively.